### PR TITLE
Allow multi-col-pk tables to be audited

### DIFF
--- a/lib/DBIx/Class/AuditAny.pm
+++ b/lib/DBIx/Class/AuditAny.pm
@@ -320,13 +320,7 @@ sub track_all_sources {
 	#$class->_init;
 	
 	push @exclude, @{$self->log_sources};
-	
-	# temp - auto exclude sources without exactly one primary key
-	foreach my $source_name ($self->schema->sources) {
-		my $Source = $self->schema->source($source_name);
-		push @exclude, $source_name unless (scalar($Source->primary_columns) == 1);
-	}
-	
+		
 	my %excl = map {$_=>1} @exclude;
 	return $self->track_sources(grep { !$excl{$_} } $self->schema->sources);
 }

--- a/lib/DBIx/Class/AuditAny/AuditContext/Source.pm
+++ b/lib/DBIx/Class/AuditAny/AuditContext/Source.pm
@@ -63,9 +63,9 @@ has 'pri_key_count', is => 'ro', isa => Int, lazy => 1, default => sub {
 sub get_pri_key_value {
 	my $self = shift;
 	my $Row = shift;
-	my @num = $self->pri_key_count;
-	return undef unless (scalar(@num) > 0);
-	return $self->_ambig_get_column($Row,$self->pri_key_column) if (scalar(@num) == 1);
+	my $num = $self->pri_key_count;
+	return undef unless ($num > 0);
+	return $self->_ambig_get_column($Row,$self->pri_key_column) if ($num == 1);
 	my $sep = $self->primary_key_separator;
 	return join($sep, map { $self->_ambig_get_column($Row,$_) } $self->primary_columns );
 }

--- a/t/014_multi_pk.t
+++ b/t/014_multi_pk.t
@@ -1,0 +1,85 @@
+# -*- perl -*-
+
+use strict;
+use warnings;
+use Test::More;
+
+use FindBin '$Bin';
+use lib "$Bin/lib";
+use TestEnv;
+
+use SQL::Translator 0.11016;
+
+use_ok( 'DBIx::Class::AuditAny' );
+
+use TestSchema::Three;
+
+my @connect = ('dbi:SQLite::memory:','','', { on_connect_call => 'use_foreign_keys' });
+
+ok(
+	my $schema = TestSchema::Three->connect(@connect),
+	"Initialize Test Database"
+);
+
+$schema->deploy;
+
+
+ok(
+	my $Auditor = DBIx::Class::AuditAny->track(
+		schema => $schema, 
+		track_all_sources => 1,
+		collector_class => 'Collector::AutoDBIC',
+		collector_params => {
+			sqlite_db => TestEnv->vardir->file('audit_three.db')->stringify,
+		},
+		datapoints => [
+			(qw(schema schema_ver changeset_ts changeset_elapsed)),
+			(qw(change_elapsed action source pri_key_value)),
+			(qw(column_name old_value new_value)),
+		],
+		rename_datapoints => {
+			changeset_elapsed => 'total_elapsed',
+			change_elapsed => 'elapsed',
+			pri_key_value => 'row_key',
+			new_value => 'new',
+			old_value => 'old',
+			column_name => 'column',
+		},
+	),
+	"Setup tracker configured to write to auto configured schema"
+);
+
+ok( 
+	$schema->resultset('Team')->create({
+		id => 1,
+		name => 'Denver Broncos' 
+	}),
+	"Insert a test row (Team table)"
+);
+
+ok( 
+	my $Position = $schema->resultset('Position')->create({
+		name => 'Quarterback' 
+	}),
+	"Insert a test row (Position table)"
+);
+
+ok( 
+  # have to specify id and sec_id due to limitation in sqlite
+	$schema->resultset('Player')->create({
+    id => 1,
+    sec_id => 1,
+		first => 'Payton',
+		last => 'Manning',
+		team_id => 1,
+		position => 'Quarterback'
+	}),
+	"Insert a test row (Player table)"
+);
+
+ok(
+  $Auditor->collector->target_schema->resultset('AuditChange')->search({row_key => '1|~|1'})->first,
+  "Found audit of dual primary key insert"
+);
+
+done_testing;

--- a/t/lib/TestSchema/Three.pm
+++ b/t/lib/TestSchema/Three.pm
@@ -1,0 +1,8 @@
+package # hide from PAUSE 
+    TestSchema::Three;
+    
+use base qw/DBIx::Class::Schema/;
+
+__PACKAGE__->load_namespaces;
+
+1;

--- a/t/lib/TestSchema/Three/Result/Player.pm
+++ b/t/lib/TestSchema/Three/Result/Player.pm
@@ -1,0 +1,33 @@
+package # hide from PAUSE 
+    TestSchema::Three::Result::Player;
+   
+use base 'DBIx::Class::Core';
+    
+__PACKAGE__->table("player");
+__PACKAGE__->add_columns(
+  "id"			=> { data_type => "integer", is_auto_increment => 1, is_nullable => 0 },
+  "sec_id"	=> { data_type => "integer", is_auto_increment => 1, is_nullable => 0 },
+  "first"		=> { data_type => "varchar", is_nullable => 0, size => 32 },
+  "last"			=> { data_type => "varchar", is_nullable => 0, size => 32 },
+  "position"	=> { data_type => "varchar", is_nullable => 0, size => 32 },
+  "team_id"		=> { data_type => "integer", is_nullable => 0 },
+);
+__PACKAGE__->set_primary_key("id", "sec_id");
+
+
+__PACKAGE__->belongs_to(
+  "team",
+  "TestSchema::Three::Result::Team",
+  { id => "team_id" },
+  { is_deferrable => 1, on_delete => "CASCADE", on_update => "CASCADE" },
+);
+
+__PACKAGE__->belongs_to(
+  "position",
+  "TestSchema::Three::Result::Position",
+  { name => "position" },
+  { is_deferrable => 1, on_delete => "CASCADE", on_update => "CASCADE" },
+);
+
+
+1;

--- a/t/lib/TestSchema/Three/Result/Position.pm
+++ b/t/lib/TestSchema/Three/Result/Position.pm
@@ -1,0 +1,22 @@
+package # hide from PAUSE 
+    TestSchema::Three::Result::Position;
+   
+use base 'DBIx::Class::Core';
+    
+__PACKAGE__->table("position");
+__PACKAGE__->add_columns(
+  "name"		=> { data_type => "varchar", is_nullable => 0, size => 32 },
+);
+__PACKAGE__->set_primary_key("name");
+
+
+__PACKAGE__->has_many(
+  "players",
+  "TestSchema::Three::Result::Player",
+  { "foreign.position" => "self.name" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+
+    
+1;

--- a/t/lib/TestSchema/Three/Result/Team.pm
+++ b/t/lib/TestSchema/Three/Result/Team.pm
@@ -1,0 +1,21 @@
+package # hide from PAUSE 
+    TestSchema::Three::Result::Team;
+   
+use base 'DBIx::Class::Core';
+    
+__PACKAGE__->table("team");
+__PACKAGE__->add_columns(
+  "id"			=> { data_type => "integer", is_auto_increment => 1, is_nullable => 0 },
+  "name"			=> { data_type => "varchar", is_nullable => 0, size => 32 },
+);
+__PACKAGE__->set_primary_key("id");
+
+
+__PACKAGE__->has_many(
+  "players",
+  "TestSchema::Three::Result::Player",
+  { "foreign.team_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+1;


### PR DESCRIPTION
This removes the temporary block when using 'track_all_changes' for tables with multi column primary keys, as well as fixing an issue with the actual creation of the pri_key_value where the checking of the number of primary keys was not correct.